### PR TITLE
Reach MusicBrainz using HTTPS

### DIFF
--- a/addrelease.py
+++ b/addrelease.py
@@ -17,7 +17,7 @@ import tempfile
 HTML_HEAD = """<!doctype html>
 <meta charset="UTF-8">
 <title>Add Cluster As Release</title>
-<form action="http://musicbrainz.org/release/add" method="post">
+<form action="https://musicbrainz.org/release/add" method="post">
 """
 HTML_INPUT = """<input type="hidden" name="%s" value="%s">
 """


### PR DESCRIPTION
MusicBrainz now redirects http to https. The redirection loses the form data, so nothing is filled when arriving on MusicBrainz website.

![2017-01-29 2](https://cloud.githubusercontent.com/assets/3317699/22403525/fddf828a-e619-11e6-99b4-fc94195fef5d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foolip/addrelease/1)
<!-- Reviewable:end -->
